### PR TITLE
Replace lazy_static with std::sync::OnceLock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ devenv.local.nix
 
 # pre-commit
 .pre-commit-config.yaml
+
+docs/.obsidian

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,6 @@ dependencies = [
  "hkdf",
  "hmac",
  "inquire",
- "lazy_static",
  "pbkdf2 0.12.2",
  "rand",
  "rust-argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ hex = "0.4.3"
 hkdf = "0.12"
 hmac = "0.12.1"
 inquire = "0.6.2"
-lazy_static = "1.4.0"
 pbkdf2 = { version = "0.12.2", features = ["simple"] }
 rand = { version = "0.8.5", features = ["getrandom"] }
 rust-argon2 = "2.0.0"

--- a/docs/Future Work.md
+++ b/docs/Future Work.md
@@ -560,8 +560,8 @@ Roughly ordered by impact-to-effort ratio, grouped into phases:
 **Phase 1 — Low-hanging fruit (hours each):**
 1. Add `zeroize` as a direct dependency, apply `ZeroizeOnDrop` to key structs, wrap intermediates in `Zeroizing<Vec<u8>>`. (Section 3.1.1)
 2. Add `prctl(PR_SET_DUMPABLE, 0)` at process start. One line. (Section 3.1.2)
-3. Bump `Cargo.toml` version to match the latest tag. (Section 6.2)
-4. Add `cargo audit` to CI. (Section 5.2)
+3. ~~Bump `Cargo.toml` version to match the latest tag. (Section 6.2)~~
+4. ~~Add `cargo audit` to CI. (Section 5.2)~~
 5. Always print fingerprint to stderr after key generation. (Section 4.4)
 6. Fix seed input echo — use non-echoing prompt for seed words. (Section 3.3.4)
 

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -5,10 +5,10 @@ use bip39::{Language, Mnemonic};
 use hmac::Mac;
 use inquire::validator::Validation;
 use inquire::{CustomUserError, Text};
-use lazy_static::lazy_static;
 use pbkdf2::password_hash::{PasswordHasher, SaltString};
 use std::fmt;
 use std::io::{self, BufRead, Write};
+use std::sync::OnceLock;
 use strsim::levenshtein;
 
 type HmacSha512 = hmac::Hmac<sha2::Sha512>;
@@ -73,15 +73,16 @@ fn wordlist() -> Result<Vec<String>> {
     Ok(words)
 }
 
-lazy_static! {
-    static ref WORDLIST: Vec<String> = wordlist().expect("Failed to read wordlist");
+fn get_wordlist() -> &'static Vec<String> {
+    static WORDLIST: OnceLock<Vec<String>> = OnceLock::new();
+    WORDLIST.get_or_init(|| wordlist().expect("Failed to read wordlist"))
 }
 
 fn suggest(
     input: &str,
 ) -> std::result::Result<Vec<std::string::String>, Box<dyn std::error::Error + Send + Sync + 'static>>
 {
-    Ok(WORDLIST
+    Ok(get_wordlist()
         .iter()
         .filter(|s| s.to_lowercase().starts_with(input))
         .map(String::from)
@@ -89,11 +90,11 @@ fn suggest(
 }
 
 fn check_word_is_valid(input: &str) -> Option<String> {
-    if WORDLIST
+    if get_wordlist()
         .binary_search_by(|s| s.as_str().cmp(input))
         .is_err()
     {
-        let closest = WORDLIST
+        let closest = get_wordlist()
             .iter()
             .min_by_key(|word| levenshtein(word, input))
             .unwrap();


### PR DESCRIPTION
## Summary
- Remove `lazy_static` dependency, replace with `std::sync::OnceLock` (stable since Rust 1.70, already used in `console.rs`)
- Add `docs/Future Work.md` with comprehensive roadmap

## Test plan
- [x] All 22 integration tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)