### PR TITLE
Print key fingerprint after generation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -265,6 +265,32 @@ fn validate(args: &Args) -> Result<()> {
     Ok(())
 }
 
+/// Format the key fingerprint for display.
+/// PGP: groups of 4 hex chars separated by spaces, with a double space in the middle
+/// (e.g. "67EA E069 0476 6020 FB5B  41B3 14B8 857D 6EFD 7E9F").
+/// SSH: SHA256 hash of the public key in base64 (e.g. "SHA256:...").
+fn format_fingerprint(args: &Args, keys: &Keys) -> Result<String> {
+    match args.format {
+        OutputFormat::Pgp => {
+            let fp = pgp::key_fingerprint(&keys.sign_key)?;
+            let hex: Vec<String> = fp.iter().map(|b| format!("{:02X}", b)).collect();
+            let formatted = hex
+                .chunks(2)
+                .map(|pair| pair.join(""))
+                .collect::<Vec<_>>()
+                .chunks(5)
+                .map(|group| group.join(" "))
+                .collect::<Vec<_>>()
+                .join("  ");
+            Ok(format!("PGP fingerprint: {}", formatted))
+        }
+        OutputFormat::Ssh => {
+            let fp = ssh::key_fingerprint(keys)?;
+            Ok(format!("SSH fingerprint: SHA256:{}", fp))
+        }
+    }
+}
+
 fn main() -> Result<()> {
     console_logln!("Welcome to BIP39Key");
 
@@ -318,24 +344,6 @@ fn main() -> Result<()> {
     }
     .expect("Could not build keys");
     console_logln!("Done generating key entropy");
-    match args.format {
-        OutputFormat::Pgp => {
-            let fp = pgp::key_fingerprint(&keys.sign_key)?;
-            let hex: Vec<String> = fp.iter().map(|b| format!("{:02X}", b)).collect();
-            let formatted = hex
-                .chunks(2)
-                .map(|pair| pair.join(""))
-                .collect::<Vec<_>>()
-                .chunks(5)
-                .map(|group| group.join(" "))
-                .collect::<Vec<_>>()
-                .join("  ");
-            console_logln!("PGP fingerprint: {}", formatted);
-        }
-        OutputFormat::Ssh => {
-            let fp = ssh::key_fingerprint(&keys)?;
-            console_logln!("SSH fingerprint: SHA256:{}", fp);
-        }
-    }
+    console_logln!("{}", format_fingerprint(&args, &keys)?);
     output_keys(&args, &keys)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,5 +318,24 @@ fn main() -> Result<()> {
     }
     .expect("Could not build keys");
     console_logln!("Done generating key entropy");
+    match args.format {
+        OutputFormat::Pgp => {
+            let fp = pgp::key_fingerprint(&keys.sign_key)?;
+            let hex: Vec<String> = fp.iter().map(|b| format!("{:02X}", b)).collect();
+            let formatted = hex
+                .chunks(2)
+                .map(|pair| pair.join(""))
+                .collect::<Vec<_>>()
+                .chunks(5)
+                .map(|group| group.join(" "))
+                .collect::<Vec<_>>()
+                .join("  ");
+            console_logln!("PGP fingerprint: {}", formatted);
+        }
+        OutputFormat::Ssh => {
+            let fp = ssh::key_fingerprint(&keys)?;
+            console_logln!("SSH fingerprint: SHA256:{}", fp);
+        }
+    }
     output_keys(&args, &keys)
 }

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -240,7 +240,7 @@ fn output_encrypted_secret_key(
     output_as_packet(PacketType::PrivateSignKey, cursor.get_ref(), out)
 }
 
-fn key_fingerprint(key: &SignKey) -> Result<Vec<u8>> {
+pub fn key_fingerprint(key: &SignKey) -> Result<Vec<u8>> {
     let mut hasher = sha1::Sha1::new();
     let mut cursor = ByteCursor::new(Vec::with_capacity(256));
     output_public_key(key, &mut cursor)?;

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -134,6 +134,15 @@ pub fn output_secret_as_pem<W: Write>(keys: &Keys, out: &mut std::io::BufWriter<
     Ok(())
 }
 
+pub fn key_fingerprint(keys: &Keys) -> Result<String> {
+    let mut cursor = ByteCursor::new(Vec::with_capacity(1024));
+    put_string("ssh-ed25519", &mut cursor)?;
+    put_bytes(&keys.sign_key.public_key, &mut cursor)?;
+    use sha2::Digest;
+    let hash = sha2::Sha256::digest(cursor.get_ref());
+    Ok(base64::encode(hash))
+}
+
 pub fn output_public_as_pem<W: Write>(keys: &Keys, out: &mut std::io::BufWriter<W>) -> Result<()> {
     let mut cursor = ByteCursor::new(Vec::with_capacity(1024));
     put_string("ssh-ed25519", &mut cursor)?;


### PR DESCRIPTION
## Summary
- Display PGP fingerprint (GPG-style `XXXX XXXX ...` groups) or SSH fingerprint (`SHA256:base64`) to the console after key generation
- Uses `console_logln!` so it only appears on interactive TTYs — zero impact on piped/scripted output
- Makes `pgp::key_fingerprint` public and adds `ssh::key_fingerprint`

## Test plan
- [x] All 22 integration tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] Piped output unchanged (fingerprint suppressed when stdout is not a TTY)
- [ ] Manual: run interactively and verify fingerprint displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)