### PR TITLE
Mask seed words in terminal scrollback

### DIFF
--- a/src/seed.rs
+++ b/src/seed.rs
@@ -167,7 +167,8 @@ pub fn from_prompt(seed_format: &SeedFormat) -> Result<Vec<u8>> {
             if i == 12 {
                 break;
             }
-            let input = Text::new(&format!("Word (currently {}): ", i + 1))
+            let word_start = i + 1;
+            let input = Text::new(&format!("Word (currently {}): ", word_start))
                 .with_validator(validate)
                 .with_autocomplete(suggest)
                 .prompt()?;
@@ -175,6 +176,16 @@ pub fn from_prompt(seed_format: &SeedFormat) -> Result<Vec<u8>> {
                 result.push(word.trim().to_string());
                 i += 1;
             }
+            // Overwrite the answered prompt line so previously entered words
+            // are not readable in terminal scrollback or screen captures.
+            // Move cursor up one line, clear it, and print a masked replacement.
+            print!("\x1b[1A\x1b[2KWord {}: ****", word_start);
+            if i > word_start {
+                // Multiple words were pasted at once.
+                print!(" ({} words entered)", i - word_start + 1);
+            }
+            println!();
+            io::stdout().flush().unwrap();
         }
         if result.is_empty() {
             continue;


### PR DESCRIPTION
## Summary
- After each seed word is entered via the interactive prompt, overwrite the answered line with `Word N: ****` using ANSI escape codes
- Words remain visible during entry (needed for autocomplete) but are masked afterward
- Reduces exposure in terminal scrollback, screen recordings, and shoulder surfing

## Test plan
- [ ] Run `cargo build --release` and invoke with interactive seed entry
- [ ] Verify each word is visible during typing with autocomplete working
- [ ] After pressing enter, verify the line is replaced with `Word N: ****`
- [ ] Paste multiple words at once and verify the masked line shows word count
- [ ] Scroll up in terminal and confirm words are not visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)