### PR TITLE
Zeroize sensitive buffers and disable core dumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "inquire",
+ "libc",
  "pbkdf2 0.12.2",
  "rand",
  "rust-argon2",
@@ -136,6 +137,7 @@ dependencies = [
  "textwrap",
  "tiny-bip39",
  "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ byteorder = "1.4.3"
 cfb-mode = "0.8.1"
 clap = { version = "4.4.11", features = ["derive"] }
 ctr = "0.9.1"
-ed25519-dalek = "2.1.0"
+ed25519-dalek = { version = "2.1.0", features = ["zeroize"] }
 hex = "0.4.3"
 hkdf = "0.12"
 hmac = "0.12.1"
@@ -25,6 +25,8 @@ rust-argon2 = "2.0.0"
 sha1 = "0.10.0"
 sha2 = "0.10.2"
 strsim = "0.11.1"
+libc = "0.2"
 textwrap = "0.16"
+zeroize = { version = "1", features = ["derive"] }
 tiny-bip39 = "1.0.0"
-x25519-dalek = { version = "2.0.0-rc3", features = ["static_secrets"] }
+x25519-dalek = { version = "2.0.0-rc3", features = ["static_secrets", "zeroize"] }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,6 +1,7 @@
 use crate::types::*;
 use hkdf::Hkdf;
 use sha2::Sha256;
+use zeroize::Zeroize;
 
 pub struct UserId {
     pub user_id: String,
@@ -13,6 +14,20 @@ pub struct SignKey {
     pub creation_timestamp_secs: i64,
     pub expiration_timestamp_secs: Option<i64>,
     pub use_authorization_for_sign_key: bool,
+}
+
+impl Zeroize for SignKey {
+    fn zeroize(&mut self) {
+        self.private_key.zeroize();
+        // Overwrite the SigningKey by replacing it with a key derived from zeroed bytes.
+        self.signing_key = ed25519_dalek::SigningKey::from_bytes(&[0u8; 32]);
+    }
+}
+
+impl Drop for SignKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
 }
 
 impl SignKey {
@@ -41,6 +56,18 @@ pub struct EncryptKey {
     pub private_key: [u8; ed25519_dalek::SECRET_KEY_LENGTH],
     pub creation_timestamp_secs: i64,
     pub expiration_timestamp_secs: Option<i64>,
+}
+
+impl Zeroize for EncryptKey {
+    fn zeroize(&mut self) {
+        self.private_key.zeroize();
+    }
+}
+
+impl Drop for EncryptKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
 }
 
 impl EncryptKey {
@@ -72,6 +99,14 @@ pub struct Keys {
     pub sign_key: SignKey,
     pub encrypt_key: Option<EncryptKey>,
     pub passphrase: Option<String>,
+}
+
+impl Drop for Keys {
+    fn drop(&mut self) {
+        if let Some(ref mut p) = self.passphrase {
+            p.zeroize();
+        }
+    }
 }
 
 /// Key derivation algorithm for combining seed and passphrase.
@@ -126,11 +161,20 @@ pub struct KeySettings {
     pub use_authorization_for_sign_key: bool,
 }
 
+impl Drop for KeySettings {
+    fn drop(&mut self) {
+        self.seed.zeroize();
+        if let Some(ref mut p) = self.passphrase {
+            p.zeroize();
+        }
+    }
+}
+
 impl Keys {
-    fn build_keys(secret_key_bytes: &[u8], settings: KeySettings) -> Result<Keys> {
+    fn build_keys(secret_key_bytes: &[u8], mut settings: KeySettings) -> Result<Keys> {
         Ok(Keys {
             user_id: UserId {
-                user_id: settings.user_id,
+                user_id: std::mem::take(&mut settings.user_id),
             },
             sign_key: SignKey::new(
                 &secret_key_bytes[..32],
@@ -147,7 +191,7 @@ impl Keys {
             } else {
                 None
             },
-            passphrase: settings.passphrase,
+            passphrase: settings.passphrase.take(),
         })
     }
 
@@ -155,10 +199,12 @@ impl Keys {
     /// The Argon2id output is used as PRK, and separate info strings produce
     /// independent sign and encrypt key material.
     pub fn new_with_hkdf(settings: KeySettings) -> Result<Keys> {
-        let prk = if let Some(pass) = &settings.passphrase {
+        let mut prk = if let Some(pass) = &settings.passphrase {
             let mut bytes = settings.seed.to_vec();
             bytes.extend_from_slice(pass.as_bytes());
-            run_argon(&bytes, &settings.user_id, settings.use_rfc9106_settings)?
+            let result = run_argon(&bytes, &settings.user_id, settings.use_rfc9106_settings)?;
+            bytes.zeroize();
+            result
         } else {
             run_argon(
                 &settings.seed,
@@ -167,18 +213,24 @@ impl Keys {
             )?
         };
         let sign_key_bytes = hkdf_expand(&prk, b"bip39key-sign-v1", 32)?;
-        let encrypt_key_bytes = hkdf_expand(&prk, b"bip39key-encrypt-v1", 32)?;
+        let mut encrypt_key_bytes = hkdf_expand(&prk, b"bip39key-encrypt-v1", 32)?;
+        prk.zeroize();
         let mut secret_key_bytes = sign_key_bytes;
         secret_key_bytes.extend_from_slice(&encrypt_key_bytes);
-        Self::build_keys(&secret_key_bytes, settings)
+        encrypt_key_bytes.zeroize();
+        let result = Self::build_keys(&secret_key_bytes, settings);
+        secret_key_bytes.zeroize();
+        result
     }
 
     pub fn new_with_concat(settings: KeySettings) -> Result<Keys> {
         // Derive 64 bytes by running Argon with the user id as salt.
-        let secret_key_bytes = if let Some(pass) = &settings.passphrase {
+        let mut secret_key_bytes = if let Some(pass) = &settings.passphrase {
             let mut bytes = settings.seed.to_vec();
             bytes.extend_from_slice(pass.as_bytes());
-            run_argon(&bytes, &settings.user_id, settings.use_rfc9106_settings)?
+            let result = run_argon(&bytes, &settings.user_id, settings.use_rfc9106_settings)?;
+            bytes.zeroize();
+            result
         } else {
             run_argon(
                 &settings.seed,
@@ -186,28 +238,33 @@ impl Keys {
                 settings.use_rfc9106_settings,
             )?
         };
-        Self::build_keys(&secret_key_bytes, settings)
+        let result = Self::build_keys(&secret_key_bytes, settings);
+        secret_key_bytes.zeroize();
+        result
     }
 
     pub fn new_with_xor(settings: KeySettings) -> Result<Keys> {
         // Derive 64 bytes by running Argon with the user id as salt
-        let secret_key_bytes = if let Some(pass) = &settings.passphrase {
-            let bytes = run_argon(
+        let mut secret_key_bytes = if let Some(pass) = &settings.passphrase {
+            let mut bytes = run_argon(
                 &settings.seed,
                 &settings.user_id,
                 settings.use_rfc9106_settings,
             )?;
             // Generate another buffer with Argon for the passphrase and XOR it.
-            let passphrase_bytes = run_argon(
+            let mut passphrase_bytes = run_argon(
                 pass.as_bytes(),
                 &settings.user_id,
                 settings.use_rfc9106_settings,
             )?;
-            bytes
+            let result: Vec<u8> = bytes
                 .iter()
                 .zip(passphrase_bytes.iter())
                 .map(|(lhs, rhs)| lhs ^ rhs)
-                .collect()
+                .collect();
+            bytes.zeroize();
+            passphrase_bytes.zeroize();
+            result
         } else {
             run_argon(
                 &settings.seed,
@@ -215,6 +272,8 @@ impl Keys {
                 settings.use_rfc9106_settings,
             )?
         };
-        Self::build_keys(&secret_key_bytes, settings)
+        let result = Self::build_keys(&secret_key_bytes, settings);
+        secret_key_bytes.zeroize();
+        result
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,7 +291,21 @@ fn format_fingerprint(args: &Args, keys: &Keys) -> Result<String> {
     }
 }
 
+/// Prevent the process from producing core dumps that could leak key material.
+/// On Linux this uses prctl(PR_SET_DUMPABLE, 0). On other platforms this is a no-op.
+fn disable_core_dumps() {
+    #[cfg(target_os = "linux")]
+    {
+        // SAFETY: prctl(PR_SET_DUMPABLE, 0) is a simple flag-setting syscall with no
+        // memory or resource side effects.
+        unsafe {
+            libc::prctl(libc::PR_SET_DUMPABLE, 0);
+        }
+    }
+}
+
 fn main() -> Result<()> {
+    disable_core_dumps();
     console_logln!("Welcome to BIP39Key");
 
     let args = Args::parse();

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -7,6 +7,7 @@ use ed25519_dalek::Signer;
 use rand::RngCore;
 use sha2::Digest;
 use std::io::Write;
+use zeroize::Zeroize;
 
 type Aes256Cfb = cfb_mode::Encryptor<aes::Aes256>;
 
@@ -101,6 +102,7 @@ fn s2k_key(passphrase: &str, salt: &[u8], count: usize) -> Vec<u8> {
     }
     let tail = count - iterations * buf.len();
     hash.update(&buf[..tail]);
+    buf.zeroize();
     hash.finalize().to_vec()
 }
 
@@ -110,7 +112,7 @@ fn s2k_encrypt(key: &[u8], passphrase: &str, out: &mut ByteCursor) -> Result<()>
     let max_s2k_count = s2k_byte_count(0xFF);
     let salt = &salt_and_iv[..8];
     let iv = &salt_and_iv[8..];
-    let encrypt_key = s2k_key(passphrase, salt, max_s2k_count);
+    let mut encrypt_key = s2k_key(passphrase, salt, max_s2k_count);
     let mut data = mpi_encode(key);
     // Compute SHA1 and append it as HMAC to the data.
     let mut mac = sha1::Sha1::new();
@@ -118,6 +120,7 @@ fn s2k_encrypt(key: &[u8], passphrase: &str, out: &mut ByteCursor) -> Result<()>
     data.extend(mac.finalize());
     // Encrypt data using AES.
     Aes256Cfb::new(encrypt_key.as_slice().into(), iv.into()).encrypt(&mut data);
+    encrypt_key.zeroize();
     // S2K Encrypted. AES256, Iterated and Salted S2k, SHA-256
     out.write_all(&[254, 9, 3, 8])?;
     out.write_all(salt)?;
@@ -173,9 +176,11 @@ fn output_unencrypted_secret_subkey(key: &EncryptKey, out: &mut ByteCursor) -> R
     // uses big-endian representation of numbers.
     let mut reverse_secret_key = key.private_key;
     reverse_secret_key.reverse();
-    let mpi_key = mpi_encode(&reverse_secret_key);
+    let mut mpi_key = mpi_encode(&reverse_secret_key);
+    reverse_secret_key.zeroize();
     cursor.write_all(&mpi_key)?;
     cursor.write_u16::<BigEndian>(checksum(&mpi_key))?;
+    mpi_key.zeroize();
     output_as_packet(PacketType::PrivateEncryptSubkey, cursor.get_ref(), out)
 }
 
@@ -192,6 +197,7 @@ fn output_encrypted_secret_subkey(
     let mut reverse_secret_key = key.private_key;
     reverse_secret_key.reverse();
     s2k_encrypt(&reverse_secret_key, passphrase, &mut cursor)?;
+    reverse_secret_key.zeroize();
     output_as_packet(PacketType::PrivateEncryptSubkey, cursor.get_ref(), out)
 }
 
@@ -222,9 +228,10 @@ fn output_unencrypted_secret_key(key: &SignKey, out: &mut ByteCursor) -> Result<
     cursor.write_all(&payload)?;
     // S2K unencrypted i.e. without passphrase protection.
     cursor.write_all(&[0])?;
-    let mpi_key = mpi_encode(&key.private_key);
+    let mut mpi_key = mpi_encode(&key.private_key);
     cursor.write_all(&mpi_key)?;
     cursor.write_u16::<BigEndian>(checksum(&mpi_key))?;
+    mpi_key.zeroize();
     output_as_packet(PacketType::PrivateSignKey, cursor.get_ref(), out)
 }
 

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -6,6 +6,7 @@ use bcrypt_pbkdf::bcrypt_pbkdf;
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
 use rand::RngCore;
 use std::io::Write;
+use zeroize::Zeroize;
 
 type Aes256Ctr = ctr::Ctr64BE<aes::Aes256>;
 
@@ -95,6 +96,7 @@ fn put_ssh_key_with_passphrase(
     bcrypt_pbkdf(passphrase, salt, rounds, &mut buf)?;
     let mut stream = Aes256Ctr::new(buf[..32].into(), buf[32..].into());
     stream.apply_keystream(content);
+    buf.zeroize();
     put_bytes(content, cursor)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Zeroize private key bytes, passphrases, and key derivation intermediates on drop using the `zeroize` crate
- Call `prctl(PR_SET_DUMPABLE, 0)` on Linux at startup to prevent core dumps from leaking key material
- Enable `zeroize` feature on `ed25519-dalek` and `x25519-dalek` for native zeroize support

### What gets zeroized
- `SignKey.private_key` and `SignKey.signing_key` (replaced with zeroed key on drop)
- `EncryptKey.private_key`
- `Keys.passphrase` and `KeySettings.{seed, passphrase}`
- Argon2id output, HKDF expanded bytes, XOR intermediates in key derivation
- S2K encryption keys, bcrypt-pbkdf derived key+IV, MPI-encoded private keys, reversed secret key copies

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] All 22 integration tests pass
- [ ] Verify on Linux: `/proc/self/dumpable` reads `0` after startup (or `cat /proc/<pid>/status | grep CoreDumping`)
- [ ] Verify on macOS: builds and runs (PR_SET_DUMPABLE is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)