### PR TITLE
Add backward-compat tests for default algorithm and -c flag

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -636,3 +636,46 @@ fn test_no_passphrase() {
         .unwrap();
     assert_eq!(message.stdout, b"Secret message!\n");
 }
+
+#[test]
+fn test_default_algorithm_is_xor() {
+    let gpg = Gpg::new();
+    let output = run_bip39key(BIP39, &userid(), &[]).unwrap();
+    gpg.import(&output.stdout, None, None);
+    let keysout = gpg.run(&["--with-colons", "--list-keys"], None).unwrap();
+    let keys = parse_gpg_keys(&keysout.stdout);
+    check_key(
+        &keys,
+        "A10531F7669DDD0FA50B0A00656C58480711970B",
+        "656C58480711970B",
+    );
+}
+
+#[test]
+fn test_concat_flag_backwards_compat() {
+    let bip39: Vec<&str> =
+        "fatigue mosquito exclude vessel reward slight protect purity language hat anger pen"
+            .split(' ')
+            .collect();
+    let password = "magic-password";
+    let uid = "Integration Test <integration@test.com>";
+    let output = run_bip39key(&bip39, uid, &["-c", "-p", password]).unwrap();
+    let gpg = Gpg::new();
+    gpg.import(&output.stdout, None, Some(password));
+    let gpg_file = golden_path("message-concatenated.gpg");
+    let gpg_file_str = gpg_file.to_str().unwrap().to_string();
+    let message = gpg
+        .run(
+            &[
+                "--passphrase",
+                password,
+                "--pinentry-mode",
+                "loopback",
+                "--decrypt",
+                &gpg_file_str,
+            ],
+            None,
+        )
+        .unwrap();
+    assert_eq!(message.stdout, b"Secret message!!\n");
+}


### PR DESCRIPTION
## Summary
- Add `test_default_algorithm_is_xor` — verifies that omitting `--algorithm` defaults to `xor` by checking the key fingerprint matches the known xor output
- Add `test_concat_flag_backwards_compat` — verifies that the deprecated `-c` flag produces the same key as `--algorithm concat` by decrypting the existing golden file

These guard against silently breaking existing key backups if the CLI defaults or flag aliases ever change.

## Test plan
- [x] Both new tests pass with `cargo test --release --test integration`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)