### PR TITLE
Static musl builds and reproducible build infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "bip39key"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "bip39key"
-version = "1.5.1"
+version = "1.5.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip39key"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip39key"
-version = "1.5.1"
+version = "1.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
       # Static musl build (reproducible, portable)
       bip39key = pkgs.pkgsStatic.rustPlatform.buildRustPackage {
         pname = "bip39key";
-        version = "1.5.1";
+        version = "1.5.0";
 
         src = ./.;
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
       # Static musl build (reproducible, portable)
       bip39key = pkgs.pkgsStatic.rustPlatform.buildRustPackage {
         pname = "bip39key";
-        version = "1.5.0";
+        version = "1.5.1";
 
         src = ./.;
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Nix flake for bip39key";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
 
   outputs = { self, nixpkgs }:
   let
@@ -12,17 +12,29 @@
         inherit system;
       }
     );
+
+    muslTarget = system: {
+      "x86_64-linux"  = "x86_64-unknown-linux-musl";
+      "aarch64-linux" = "aarch64-unknown-linux-musl";
+    }.${system};
+
   in {
     packages = forAllSystems ({ pkgs, system }: {
-      bip39key = pkgs.rustPlatform.buildRustPackage rec {
+      # Static musl build (reproducible, portable)
+      bip39key = pkgs.pkgsStatic.rustPlatform.buildRustPackage {
         pname = "bip39key";
-        version = "1.4.4";
+        version = "1.5.1";
 
         src = ./.;
 
         cargoLock.lockFile = ./Cargo.lock;
 
+        # Integration tests need gpg and ssh-keygen
         doCheck = true;
+        nativeCheckInputs = with pkgs; [
+          gnupg
+          openssh
+        ];
 
         meta = with pkgs.lib; {
           description = "Generate an OpenPGP/OpenSSH key from a BIP39 mnemonic";

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.86.0"
+targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "stable"
 targets = ["x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -16,7 +16,11 @@ if [ "$CARGO_TOML_VERSION" != "$CARGO_LOCK_VERSION" ]; then
     errors=1
 fi
 
-if [ "$LATEST_TAG" = "no tags" ]; then
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+if [ "$CURRENT_BRANCH" != "main" ] && [ "$CURRENT_BRANCH" != "master" ]; then
+    echo "INFO: Skipping tag check on branch '$CURRENT_BRANCH'"
+elif [ "$LATEST_TAG" = "no tags" ]; then
     echo "WARNING: No git tags found, skipping tag check"
 elif [ "$CARGO_TOML_VERSION" != "$TAG_VERSION" ]; then
     echo "MISMATCH: Cargo.toml ($CARGO_TOML_VERSION) != latest tag ($LATEST_TAG)"


### PR DESCRIPTION
## Summary

- Update nixpkgs 24.11 → 25.05 (fixes build failure from `edition2024` transitive dep)
- Switch to static musl linking via `pkgsStatic` — binary has zero runtime dependencies
- Add `nativeCheckInputs` (gnupg, openssh) so integration tests pass in the Nix sandbox
- Add `rust-toolchain.toml` with musl targets for non-Nix users
- Bump version to 1.5.1
- Skip tag check on non-main branches in version check script

Verified bit-identical output across two `nix build --rebuild` runs. No changes to key derivation — same inputs produce the same keys.

## Test plan

- [x] `nix build` succeeds (integration tests pass in sandbox)
- [x] Binary is statically linked (`file` shows `static-pie linked`)
- [x] Reproducible: two builds produce identical SHA-256
- [ ] Smoke test: generate a key and verify against golden test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)