### PR TITLE
Add authentication subkey support for HKDF algorithm

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -43,6 +43,13 @@ pub struct EncryptKey {
     pub expiration_timestamp_secs: Option<i64>,
 }
 
+pub struct AuthKey {
+    pub public_key: [u8; ed25519_dalek::PUBLIC_KEY_LENGTH],
+    pub private_key: [u8; ed25519_dalek::SECRET_KEY_LENGTH],
+    pub creation_timestamp_secs: i64,
+    pub expiration_timestamp_secs: Option<i64>,
+}
+
 impl EncryptKey {
     pub fn new(
         secret_key_bytes: &[u8],
@@ -67,10 +74,29 @@ impl EncryptKey {
     }
 }
 
+impl AuthKey {
+    pub fn new(
+        secret_key_bytes: &[u8],
+        creation_timestamp_secs: i64,
+        expiration_timestamp_secs: Option<i64>,
+    ) -> Result<AuthKey> {
+        let mut input = [0u8; 32];
+        input.copy_from_slice(secret_key_bytes);
+        let secret_key = ed25519_dalek::SigningKey::from_bytes(&input);
+        Ok(AuthKey {
+            creation_timestamp_secs,
+            expiration_timestamp_secs,
+            public_key: secret_key.verifying_key().to_bytes(),
+            private_key: secret_key.to_bytes(),
+        })
+    }
+}
+
 pub struct Keys {
     pub user_id: UserId,
     pub sign_key: SignKey,
     pub encrypt_key: Option<EncryptKey>,
+    pub auth_key: Option<AuthKey>,
     pub passphrase: Option<String>,
 }
 
@@ -122,6 +148,7 @@ pub struct KeySettings {
     pub creation_timestamp_secs: i64,
     pub expiration_timestamp_secs: Option<i64>,
     pub generate_encrypt_key: bool,
+    pub generate_auth_key: bool,
     pub use_rfc9106_settings: bool,
     pub use_authorization_for_sign_key: bool,
 }
@@ -147,6 +174,7 @@ impl Keys {
             } else {
                 None
             },
+            auth_key: None,
             passphrase: settings.passphrase,
         })
     }
@@ -155,6 +183,9 @@ impl Keys {
     /// The Argon2id output is used as PRK, and separate info strings produce
     /// independent sign and encrypt key material.
     pub fn new_with_hkdf(settings: KeySettings) -> Result<Keys> {
+        let generate_auth_key = settings.generate_auth_key;
+        let creation_timestamp_secs = settings.creation_timestamp_secs;
+        let expiration_timestamp_secs = settings.expiration_timestamp_secs;
         let prk = if let Some(pass) = &settings.passphrase {
             let mut bytes = settings.seed.to_vec();
             bytes.extend_from_slice(pass.as_bytes());
@@ -170,7 +201,16 @@ impl Keys {
         let encrypt_key_bytes = hkdf_expand(&prk, b"bip39key-encrypt-v1", 32)?;
         let mut secret_key_bytes = sign_key_bytes;
         secret_key_bytes.extend_from_slice(&encrypt_key_bytes);
-        Self::build_keys(&secret_key_bytes, settings)
+        let mut keys = Self::build_keys(&secret_key_bytes, settings)?;
+        if generate_auth_key {
+            let auth_key_bytes = hkdf_expand(&prk, b"bip39key-auth-v1", 32)?;
+            keys.auth_key = Some(AuthKey::new(
+                &auth_key_bytes,
+                creation_timestamp_secs,
+                expiration_timestamp_secs,
+            )?);
+        }
+        Ok(keys)
     }
 
     pub fn new_with_concat(settings: KeySettings) -> Result<Keys> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,7 +266,7 @@ fn validate(args: &Args) -> Result<()> {
     if args.use_concatenation && args.algorithm != keys::KeyAlgorithm::Xor {
         bail!("-c/--use-concatenation cannot be combined with --algorithm. Use --algorithm alone.");
     }
-    if args.auth_subkey && args.algorithm != keys::KeyAlgorithm::Hkdf && !args.use_concatenation {
+    if args.auth_subkey && args.algorithm != keys::KeyAlgorithm::Hkdf {
         bail!("--auth-subkey requires --algorithm hkdf.");
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,10 @@ struct Args {
     #[clap(short = 'b', long)]
     authorization_for_sign_key: bool,
 
+    /// Generate a separate authentication subkey (requires --algorithm hkdf).
+    #[clap(long)]
+    auth_subkey: bool,
+
     /// Do not add the passphrase as extra entropy. If set, the passphrase will only be used to
     /// encrypt the PGP or SSH key contents, and the key material itself will be generated from
     /// the seed and the user id.
@@ -262,6 +266,9 @@ fn validate(args: &Args) -> Result<()> {
     if args.use_concatenation && args.algorithm != keys::KeyAlgorithm::Xor {
         bail!("-c/--use-concatenation cannot be combined with --algorithm. Use --algorithm alone.");
     }
+    if args.auth_subkey && args.algorithm != keys::KeyAlgorithm::Hkdf && !args.use_concatenation {
+        bail!("--auth-subkey requires --algorithm hkdf.");
+    }
     Ok(())
 }
 
@@ -315,6 +322,7 @@ fn main() -> Result<()> {
         creation_timestamp_secs,
         expiration_timestamp_secs,
         generate_encrypt_key: !args.just_signkey,
+        generate_auth_key: args.auth_subkey,
         use_rfc9106_settings: args.use_rfc9106_settings,
         use_authorization_for_sign_key: args.authorization_for_sign_key,
     };

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -11,7 +11,7 @@ use std::io::Write;
 type Aes256Cfb = cfb_mode::Encryptor<aes::Aes256>;
 
 pub enum PacketType {
-    PrivateEncryptSubkey,
+    PrivateSubkey,
     PrivateSignKey,
     PublicSignKey,
     PublicSubKey,
@@ -43,7 +43,7 @@ fn output_as_packet(
 ) -> Result<()> {
     let type_byte: u8 = 0xc0
         | match packet_type {
-            PacketType::PrivateEncryptSubkey => 7,
+            PacketType::PrivateSubkey => 7,
             PacketType::PrivateSignKey => 5,
             PacketType::PublicSignKey => 6,
             PacketType::PublicSubKey => 14,
@@ -176,7 +176,7 @@ fn output_unencrypted_secret_subkey(key: &EncryptKey, out: &mut ByteCursor) -> R
     let mpi_key = mpi_encode(&reverse_secret_key);
     cursor.write_all(&mpi_key)?;
     cursor.write_u16::<BigEndian>(checksum(&mpi_key))?;
-    output_as_packet(PacketType::PrivateEncryptSubkey, cursor.get_ref(), out)
+    output_as_packet(PacketType::PrivateSubkey, cursor.get_ref(), out)
 }
 
 fn output_encrypted_secret_subkey(
@@ -192,7 +192,112 @@ fn output_encrypted_secret_subkey(
     let mut reverse_secret_key = key.private_key;
     reverse_secret_key.reverse();
     s2k_encrypt(&reverse_secret_key, passphrase, &mut cursor)?;
-    output_as_packet(PacketType::PrivateEncryptSubkey, cursor.get_ref(), out)
+    output_as_packet(PacketType::PrivateSubkey, cursor.get_ref(), out)
+}
+
+fn public_auth_subkey_payload(key: &AuthKey) -> Result<Vec<u8>> {
+    let mut cursor = ByteCursor::new(Vec::with_capacity(256));
+    cursor.write_all(&[0x04])?; // Version 4.
+    cursor.write_u32::<BigEndian>(key.creation_timestamp_secs.try_into().unwrap())?;
+    cursor.write_all(&[22])?; // Algorithm, EdDSA
+    let oid: [u8; 9] = [0x2b, 0x06, 0x01, 0x04, 0x01, 0xda, 0x47, 0x0f, 0x01]; // EdDSA OID
+    cursor.write_all(&[oid.len().try_into()?])?;
+    cursor.write_all(&oid)?;
+    cursor.write_u16::<BigEndian>(263)?;
+    cursor.write_all(&[0x40])?;
+    cursor.write_all(&key.public_key)?;
+    Ok(cursor.into_inner())
+}
+
+fn output_public_auth_subkey(key: &AuthKey, cursor: &mut ByteCursor) -> Result<()> {
+    let payload = public_auth_subkey_payload(key)?;
+    output_as_packet(PacketType::PublicSubKey, &payload, cursor)
+}
+
+fn output_unencrypted_secret_auth_subkey(key: &AuthKey, out: &mut ByteCursor) -> Result<()> {
+    let mut cursor = ByteCursor::new(Vec::with_capacity(256));
+    let payload = public_auth_subkey_payload(key)?;
+    cursor.write_all(&payload)?;
+    // S2K unencrypted i.e. without passphrase protection.
+    cursor.write_all(&[0])?;
+    let mpi_key = mpi_encode(&key.private_key);
+    cursor.write_all(&mpi_key)?;
+    cursor.write_u16::<BigEndian>(checksum(&mpi_key))?;
+    output_as_packet(PacketType::PrivateSubkey, cursor.get_ref(), out)
+}
+
+fn output_encrypted_secret_auth_subkey(
+    key: &AuthKey,
+    passphrase: &str,
+    out: &mut ByteCursor,
+) -> Result<()> {
+    let mut cursor = ByteCursor::new(Vec::with_capacity(256));
+    let payload = public_auth_subkey_payload(key)?;
+    cursor.write_all(&payload)?;
+    s2k_encrypt(&key.private_key, passphrase, &mut cursor)?;
+    output_as_packet(PacketType::PrivateSubkey, cursor.get_ref(), out)
+}
+
+fn output_auth_subkey_signature(
+    key: &SignKey,
+    auth_key: &AuthKey,
+    out: &mut ByteCursor,
+) -> Result<()> {
+    let mut packet_cursor = ByteCursor::new(Vec::with_capacity(256));
+    // Version 4 signature.
+    // Subkey binding signature (0x18).
+    // EdDSA signature (22), SHA-256 hash (8).
+    packet_cursor.write_all(&[0x04, 0x18, 22, 8])?;
+    // Write subpackets to a buffer.
+    // Signature creation time subpacket (2), 5 bytes.
+    let mut subpacket_cursor = ByteCursor::new(Vec::with_capacity(256));
+    subpacket_cursor.write_all(&[5, 2])?;
+    subpacket_cursor.write_u32::<BigEndian>(key.creation_timestamp_secs.try_into().unwrap())?;
+    // Expiration time in seconds (3), if provided.
+    if let Some(expiration_time_secs) = auth_key.expiration_timestamp_secs {
+        subpacket_cursor.write_all(&[5, 3])?;
+        let expiration_delta_secs = expiration_time_secs - auth_key.creation_timestamp_secs;
+        subpacket_cursor.write_u32::<BigEndian>(expiration_delta_secs.try_into().unwrap())?;
+    }
+    // Issuer subpacket (16), signature key id.
+    let key_fp = key_fingerprint(key)?;
+    subpacket_cursor.write_all(&[9, 16])?;
+    subpacket_cursor.write_all(&key_fp[12..20])?;
+    // Issuer fingerprint (33), version 4.
+    subpacket_cursor.write_all(&[22, 33, 4])?;
+    subpacket_cursor.write_all(&key_fp)?;
+    // Key Flags (27) subpacket (authentication).
+    subpacket_cursor.write_all(&[2, 27, 0x20])?;
+    // Trust signature: 120 for complete trust.
+    subpacket_cursor.write_all(&[3, 5, 0, 120])?;
+    // Write subpackets into the hashed subpacket area.
+    let subpackets = subpacket_cursor.get_ref();
+    packet_cursor.write_u16::<BigEndian>(subpackets.len() as u16)?;
+    packet_cursor.write_all(subpackets)?;
+    // Compute total hash of the public key + auth public key + subpackets + trailer.
+    let mut hasher = sha2::Sha256::new();
+    let sign_public_key = public_key_payload(key)?;
+    hasher.update([0x99]);
+    hash_u16(sign_public_key.len().try_into()?, &mut hasher);
+    hasher.update(&sign_public_key);
+    let auth_public_key = public_auth_subkey_payload(auth_key)?;
+    hasher.update([0x99]);
+    hash_u16(auth_public_key.len().try_into()?, &mut hasher);
+    hasher.update(&auth_public_key);
+    let packet = packet_cursor.get_ref();
+    hasher.update(packet);
+    hasher.update([0x04, 0xFF]);
+    hash_u32(packet.len().try_into()?, &mut hasher);
+    let hash = hasher.finalize();
+    // Sign the hash.
+    let signature = key.signing_key.sign(&hash).to_bytes();
+    // No unhashed subpackets.
+    packet_cursor.write_u16::<BigEndian>(0)?;
+    // Push the signature of the hash.
+    packet_cursor.write_all(&hash[..2])?;
+    packet_cursor.write_all(&mpi_encode(&signature[..32]))?;
+    packet_cursor.write_all(&mpi_encode(&signature[32..]))?;
+    output_as_packet(PacketType::Signature, packet_cursor.get_ref(), out)
 }
 
 fn public_key_payload(key: &SignKey) -> Result<Vec<u8>> {
@@ -398,6 +503,14 @@ pub fn output_as_packets<W: Write>(keys: &Keys, out: &mut std::io::BufWriter<W>)
         }
         output_subkey_signature(&keys.sign_key, encrypt_key, &mut buffer)?;
     }
+    if let Some(auth_key) = &keys.auth_key {
+        if let Some(passphrase) = &keys.passphrase {
+            output_encrypted_secret_auth_subkey(auth_key, passphrase, &mut buffer)?;
+        } else {
+            output_unencrypted_secret_auth_subkey(auth_key, &mut buffer)?;
+        }
+        output_auth_subkey_signature(&keys.sign_key, auth_key, &mut buffer)?;
+    }
     out.write_all(buffer.get_ref())?;
     Ok(())
 }
@@ -471,6 +584,10 @@ pub fn output_public_as_packets<W: Write>(
     if let Some(encrypt_key) = &keys.encrypt_key {
         output_public_subkey(encrypt_key, &mut buffer)?;
         output_subkey_signature(&keys.sign_key, encrypt_key, &mut buffer)?;
+    }
+    if let Some(auth_key) = &keys.auth_key {
+        output_public_auth_subkey(auth_key, &mut buffer)?;
+        output_auth_subkey_signature(&keys.sign_key, auth_key, &mut buffer)?;
     }
     out.write_all(buffer.get_ref())?;
     Ok(())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -609,6 +609,94 @@ fn test_authentication() {
 }
 
 #[test]
+fn test_auth_subkey() {
+    let bip39: Vec<&str> =
+        "switch limit barely shoot ritual reveal bomb obey luxury around language build"
+            .split(' ')
+            .collect();
+    let password = "magic-password";
+    let uid = "Integration Test <integration@test.com>";
+    let output = run_bip39key(
+        &bip39,
+        uid,
+        &["-p", password, "--algorithm", "hkdf", "--auth-subkey"],
+    )
+    .unwrap();
+    let gpg = Gpg::new();
+    gpg.import(&output.stdout, None, Some(password));
+    let keysout = gpg.run(&["--with-colons", "--list-keys"], None).unwrap();
+    let stdout = String::from_utf8_lossy(&keysout.stdout);
+    // Verify there are two subkeys: one encrypt (e) and one auth (a).
+    let sub_lines: Vec<&str> = stdout.lines().filter(|l| l.starts_with("sub:")).collect();
+    assert_eq!(
+        sub_lines.len(),
+        2,
+        "Expected 2 subkeys, got: {:?}",
+        sub_lines
+    );
+    let caps: Vec<String> = sub_lines
+        .iter()
+        .map(|l| l.split(':').nth(11).unwrap_or("").to_string())
+        .collect();
+    assert!(
+        caps.iter().any(|c| c.contains('e')),
+        "Expected encrypt capability in subkeys: {:?}",
+        caps
+    );
+    assert!(
+        caps.iter().any(|c| c.contains('a')),
+        "Expected authentication capability in subkeys: {:?}",
+        caps
+    );
+}
+
+#[test]
+fn test_auth_subkey_without_passphrase() {
+    let gpg = Gpg::new();
+    let output = run_bip39key(BIP39, &userid(), &["--algorithm", "hkdf", "--auth-subkey"]).unwrap();
+    gpg.import(&output.stdout, None, None);
+    let keysout = gpg.run(&["--with-colons", "--list-keys"], None).unwrap();
+    let stdout = String::from_utf8_lossy(&keysout.stdout);
+    let sub_lines: Vec<&str> = stdout.lines().filter(|l| l.starts_with("sub:")).collect();
+    assert_eq!(
+        sub_lines.len(),
+        2,
+        "Expected 2 subkeys, got: {:?}",
+        sub_lines
+    );
+    let caps: Vec<String> = sub_lines
+        .iter()
+        .map(|l| l.split(':').nth(11).unwrap_or("").to_string())
+        .collect();
+    assert!(
+        caps.iter().any(|c| c.contains('a')),
+        "Expected authentication capability in subkeys: {:?}",
+        caps
+    );
+}
+
+#[test]
+fn test_auth_subkey_public_key() {
+    let gpg = Gpg::new();
+    let output = run_bip39key(
+        BIP39,
+        &userid(),
+        &["--algorithm", "hkdf", "--auth-subkey", "--public-key"],
+    )
+    .unwrap();
+    gpg.import(&output.stdout, None, None);
+    let keysout = gpg.run(&["--with-colons", "--list-keys"], None).unwrap();
+    let stdout = String::from_utf8_lossy(&keysout.stdout);
+    let sub_lines: Vec<&str> = stdout.lines().filter(|l| l.starts_with("sub:")).collect();
+    assert_eq!(
+        sub_lines.len(),
+        2,
+        "Expected 2 subkeys, got: {:?}",
+        sub_lines
+    );
+}
+
+#[test]
 fn test_no_passphrase() {
     let bip39: Vec<&str> =
         "switch limit barely shoot ritual reveal bomb obey luxury around language build"


### PR DESCRIPTION
## Summary
- Adds a separate EdDSA authentication subkey derived via HKDF with domain-separated info string `bip39key-auth-v1`
- New `--auth-subkey` CLI flag (requires `--algorithm hkdf`) generates an independent authentication subkey alongside the existing sign and encrypt keys
- PGP output emits the auth key as a subkey with key flag `0x20` (authentication), with proper binding signature

## Test plan
- [x] `test_auth_subkey` — verifies GPG sees both encrypt and auth subkeys with passphrase
- [x] `test_auth_subkey_without_passphrase` — same without passphrase
- [x] `test_auth_subkey_public_key` — public key export includes auth subkey
- [x] All 27 tests pass (24 existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)